### PR TITLE
Make websockets great

### DIFF
--- a/src/kee_frame/state.cljc
+++ b/src/kee_frame/state.cljc
@@ -8,8 +8,6 @@
 
 (def app-db-spec (atom nil))
 
-(def websockets (atom {}))
-
 (def debug? (atom false))
 
 (def default-links [{:effect-present? (fn [effects] (:http-xhrio effects))
@@ -20,7 +18,6 @@
 ;; Test utility
 (defn reset-state! []
   (reset! controllers {})
-  (reset! websockets {})
   (reset! links default-links)
   (reset! router nil)
   (reset! navigator nil))


### PR DESCRIPTION
- Remove websockets atom from state, not in use
- ::connected event: Store ws-chan with correct key in db
- ::close event: Close channels, clear sockets in db for path to be closed
- ::disconnected event: Check if sockets for path exists in db before updating state to :disconnected and/or attempting reconnect
- send-messages! fn: Check if puts and takes from channels are successful. If put on ws-chan is unsuccessful, put message back in buffer-chan.