### PR TITLE
Make screen breakpoints optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,8 +376,9 @@ Most web apps benefit from having direct access to information about the size an
 ships with the nice and simple [breaking-points](https://github.com/gadfly361/breaking-point) library that provides 
 subscriptions for the screen properties you're interested in.
 
-The screen breakpoints are completely configurable, you can pass your preferred ones to the `start` function. The ones
-listed in the example below are the defaults, so if you're happy with those you can skip this config.
+The screen breakpoints are completely configurable, you can pass your preferred ones to the `start!` function. The ones
+listed in the example below are the defaults, so if you're happy with those you can just pass `true` to the `:screen`
+parameter. If you omit it altogether, or pass `false` - the screen breakpoints will be disabled.
 
 ```clojure
 (k/start!  {:screen {:breakpoints 

--- a/src/kee_frame/router.cljc
+++ b/src/kee_frame/router.cljc
@@ -102,10 +102,12 @@
   (when initial-db
     (rf/dispatch-sync [:init initial-db]))
 
-  (if @state/breakpoints-initialized?
-    (interop/set-breakpoint-subs screen)
-    (do (interop/set-breakpoints screen)
-        (reset! state/breakpoints-initialized? true)))
+  (when screen
+    (let [config (when-not (boolean? screen) screen)]
+      (if @state/breakpoints-initialized?
+        (interop/set-breakpoint-subs config)
+        (do (interop/set-breakpoints config)
+            (reset! state/breakpoints-initialized? true)))))
 
   (rf/reg-sub :kee-frame/route (fn [db] (:kee-frame/route db nil)))
   (interop/render-root (or root-component


### PR DESCRIPTION
As we talked on Slack, this makes the screen breakpoints optional. If the `screen` parameter is omitted, nothing will be enabled. If `true` is passed to it, they will be enabled with the defaults, and if a map is passed - it will be used to configure the breaking points.