### PR TITLE
Fix handling of hash fragment to enable a hash given to "/".

### DIFF
--- a/src/kee_frame/router.cljc
+++ b/src/kee_frame/router.cljc
@@ -54,7 +54,7 @@
          (when-some [h (:hash path-params)] (str "#" h)))))
 
 (defn match-url [routes url]
-  (let [[path+query fragment] (-> url (str/replace #"^/#" "") (str/split #"#" 2))
+  (let [[path+query fragment] (-> url (str/replace #"^/#/" "/") (str/split #"#" 2))
         [path query] (str/split path+query #"\?" 2)]
     (some-> (reitit/match-by-path routes path)
             (assoc :query-string query :hash fragment))))


### PR DESCRIPTION
I found this while intergrating with auth0 - it redirects back to a url adding
the hash fragment. So the url is something like "/#foo=bar&baz=1". The previous
logic caused this to become just "foo=bar&baz=1" and everything goes wrong. When
we are using hash fragment routing we only want to match on "/#/" rather than
just "/#".