### PR TITLE
Add ignored second argument to subscription

### DIFF
--- a/src/kee_frame/router.cljc
+++ b/src/kee_frame/router.cljc
@@ -137,7 +137,7 @@
         (do (interop/set-breakpoints config)
             (reset! state/breakpoints-initialized? true)))))
 
-  (rf/reg-sub :kee-frame/route (fn [db] (:kee-frame/route db nil)))
+  (rf/reg-sub :kee-frame/route (fn [db _] (:kee-frame/route db nil)))
   (interop/render-root root-component))
 
 (defn make-route-component [component route]


### PR DESCRIPTION
As far as I'm aware the second argument to a re-frame subscription is always required. While this is not an issue for cljs, in clj arities are strictly checked and I'd like to include a navigation in a clj test.