### PR TITLE
:base-path option to allow deployment on non-root paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ pom.xml.asc
 .nrepl-port
 /.idea/*
 *.iml
+/.cpcache/
+/.clj-kondo/.cache/
+/.lsp/.cache/
+/.calva/output-window/

--- a/src/kee_frame/core.cljc
+++ b/src/kee_frame/core.cljc
@@ -2,14 +2,13 @@
   (:require [kee-frame.legacy :as legacy]
             [kee-frame.state :as state]
             [kee-frame.router :as router]
-            [re-frame.core :as rf :refer [console]]
             [kee-frame.log :as log]
             [kee-frame.spec :as spec]
             [re-frame.interop :as interop]
             [clojure.spec.alpha :as s]
             [expound.alpha :as e]))
 
-(def valid-option-key? #{:router :hash-routing? :routes :process-route :debug? :debug-config
+(def valid-option-key? #{:router :hash-routing? :base-path :routes :process-route :debug? :debug-config
                          :chain-links :app-db-spec :root-component :initial-db :log-spec-error
                          :screen :scroll :route-change-event :not-found :log :global-interceptors})
 


### PR DESCRIPTION
I would like to be able to deploy kee-frame applications on github project pages which typically look like yourname.github.io/your-project.  This does not work at all unless you disable route hashing.  But then your application will only work as long as you start it by going to the root route.  If you reload the page while on a route not backed by an actual page you get an error.

* original kee-frame: https://grmble.github.io/learn-you-a-keeframe/part2/
* with these commit: https://grmble.github.io/learn-you-a-keeframe/part3/

Another option would be to have reitit do all the work.  There is a `:path` option and a `:use-fragment` option, but I did not actually try this.  https://cljdoc.org/d/metosin/reitit/0.5.18/doc/frontend/browser-integration

fixes #109 