### PR TITLE
Bug fix and reword for scrolling feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,11 +435,13 @@ You can optionally include your own error-handling component function as the fir
 ## Scroll behavior on navigation
 In a traditional static website, the browser handles the scrolling for you nicely. Meaning that when you navigate back
 and forward, the browser "remembers" how far down you scrolled on the last visit. This is convenient for many websites,
-so Kee-frame utilizes a third-party JS lib to get this behavior for a SPA. The only thing you need to do is this in
-your main namespace:
+so Kee-frame utilizes a third-party JS lib to get this behavior for a SPA. This functionality is enabled by default,
+but if you want to disable it just pass the following to `kf/start!`:
 
 ```clojure
-(:require [kee-frame.scroll])
+(k/start!  {:scroll false
+            ;; Other settings here
+            })
 ```
 
 ## Credits

--- a/src/kee_frame/router.cljc
+++ b/src/kee_frame/router.cljc
@@ -103,7 +103,9 @@
       (when scroll
         (scroll/monitor-requests! route))
       (let [{:keys [update-controllers dispatch-n]} (controller/controller-effects @state/controllers ctx route)]
-        (cond-> {:db             (assoc db :kee-frame/route route)
+        (cond-> {:db             (cond-> db
+                                   :always (assoc :kee-frame/route route)
+                                   scroll (assoc-in [:route-counter :route] route))
                  :dispatch-later [(when scroll
                                     {:ms       50
                                      :dispatch [::scroll/poll route 0]})]}


### PR DESCRIPTION
Does two things:
- Adjusts the wording in the README to better reflect current code
- Fix a bug where pages don't scroll if there's no ajax request made

This is just a tweak instead of an overhaul.
I can imagine removing `[:route-counter :route]` and just using `:kee-frame/route`, but I didn't feel like making a bigger change than was needed.

Closes #108 