### PR TITLE
Bug fix and reword for scrolling feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,11 +435,13 @@ You can optionally include your own error-handling component function as the fir
 ## Scroll behavior on navigation
 In a traditional static website, the browser handles the scrolling for you nicely. Meaning that when you navigate back
 and forward, the browser "remembers" how far down you scrolled on the last visit. This is convenient for many websites,
-so Kee-frame utilizes a third-party JS lib to get this behavior for a SPA. The only thing you need to do is this in
-your main namespace:
+so Kee-frame utilizes a third-party JS lib to get this behavior for a SPA. This functionality is enabled by default,
+but if you want to disable it just pass the following to `kf/start!`:
 
 ```clojure
-(:require [kee-frame.scroll])
+(k/start!  {:scroll false
+            ;; Other settings here
+            })
 ```
 
 ## Credits

--- a/src/kee_frame/router.cljc
+++ b/src/kee_frame/router.cljc
@@ -81,7 +81,8 @@
         (some->> not-found (match-url routes))
         (route-match-not-found routes url))))
 
-(defn bootstrap-routes [{:keys [routes router hash-routing? scroll route-change-event not-found]}]
+(defn bootstrap-routes [{:keys [routes router hash-routing? scroll route-change-event not-found]
+                         :or {scroll true}}]
   (let [initialized? (boolean @state/navigator)
         router (or router (->ReititRouter (reitit/router routes) hash-routing? not-found))]
     (reset! state/router router)

--- a/src/kee_frame/router.cljc
+++ b/src/kee_frame/router.cljc
@@ -100,13 +100,9 @@
   (rf/reg-event-fx ::route-changed
     [event-logger/interceptor]
     (fn [{:keys [db] :as ctx} [_ route]]
-      (when scroll
-        (scroll/monitor-requests! route))
       (let [{:keys [update-controllers dispatch-n]} (controller/controller-effects @state/controllers ctx route)]
-        (cond-> {:db             (assoc db :kee-frame/route route)
-                 :dispatch-later [(when scroll
-                                    {:ms       50
-                                     :dispatch [::scroll/poll route 0]})]}
+        (cond-> {:db (assoc db :kee-frame/route route)}
+          scroll (scroll/monitor-requests! route)
           dispatch-n (assoc :dispatch-n dispatch-n)
           update-controllers (assoc :update-controllers update-controllers))))))
 

--- a/src/kee_frame/scroll.clj
+++ b/src/kee_frame/scroll.clj
@@ -2,4 +2,4 @@
 
 (defn start! [])
 
-(defn monitor-requests! [_])
+(defn monitor-requests! [& _])

--- a/src/kee_frame/scroll.cljs
+++ b/src/kee_frame/scroll.cljs
@@ -9,10 +9,7 @@
                    (update db ::route-counter inc-or-dec)))
 
 (defn start! []
-  (clerk/initialize!))
-
-(defn monitor-requests! [route]
-  (clerk/navigate-page! (:path route))
+  (clerk/initialize!)
   (swap! ajax/default-interceptors
          (fn [interceptors]
            (conj (filter #(not= "route-interceptor" (:name %)) interceptors)
@@ -23,6 +20,11 @@
                                        :response (fn [response]
                                                    (rf/dispatch [::connection-balance dec])
                                                    response)})))))
+
+(defn monitor-requests! [fx route]
+  (clerk/navigate-page! (:path route))
+  (assoc fx :dispatch-later [{:ms       50
+                              :dispatch [::poll route 0]}]))
 
 (rf/reg-event-fx ::scroll
                  (fn [_ _]


### PR DESCRIPTION
Does two things:

- Adjusts the wording in the README to better reflect current code
- Fix a bug where pages don't scroll if there's no ajax request made

It does this by changing `:route-counter` to be just a pure number and not keep track of the route.
Now:
- `::poll` checks against the `:kee-frame/route` which is updated before `::poll` is called
- Ajax interceptors are only setup once (a small efficiency gain)
- `monitor-requests!` is part of the `cond->` in `::route-changed` which seems a bit cleaner

---

I've tested that this works against this repo I created: https://github.com/ake-temp/kee-frame-scroll-repro
